### PR TITLE
[JENKINS-49649] - Update the plugin to make it compatible with Jenkins 2.102+

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Build the plugin using https://github.com/jenkins-infra/pipeline-library
+buildPlugin(jenkinsVersions: [null, '2.107'])

--- a/pom.xml
+++ b/pom.xml
@@ -16,10 +16,10 @@
     This plugin reads folder, file or symbolic link names from filesystem path as parameter value.
   </description>
 
-	<properties>
-		<jenkins.version>1.625.3</jenkins.version>
-		<java.level>7</java.level>
-	</properties>
+  <properties>
+    <jenkins.version>1.625.3</jenkins.version>
+    <java.level>7</java.level>
+  </properties>
 
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.520</version>
+		<version>3.5</version>
 	</parent>
 
 	<groupId>aendter.jenkins.plugins</groupId>
@@ -11,10 +11,15 @@
 	<version>0.0.4-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 
-    <name>Jenkins Filesystem List Parameter Plug-in</name>
+	<name>Jenkins Filesystem List Parameter Plug-in</name>
   <description>
     This plugin reads folder, file or symbolic link names from filesystem path as parameter value.
   </description>
+
+	<properties>
+		<jenkins.version>1.625.3</jenkins.version>
+		<java.level>7</java.level>
+	</properties>
 
   <licenses>
     <license>
@@ -29,9 +34,7 @@
     <url>https://github.com/jenkinsci/filesystem-list-parameter-plugin</url>
   </scm>
 
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Filesystem+List+Parameter+Plug-in</url>
-
-
+  <url>https://wiki.jenkins.io/display/JENKINS/Filesystem+List+Parameter+Plug-in</url>
 
 	<developers>
 		<developer>
@@ -47,24 +50,15 @@
 	<repositories>
 		<repository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</repository>
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
-	
-	<dependencies>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<scope>test</scope>
-	    </dependency>
-	</dependencies>
 
 </project>

--- a/src/main/java/alex/jenkins/plugins/FileSystemListParameterDefinition.java
+++ b/src/main/java/alex/jenkins/plugins/FileSystemListParameterDefinition.java
@@ -218,7 +218,7 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 
 
 
-	List<String> sortList(Map<String, Long> map) {
+	 List<String> sortList(Map<String, Long> map) {
 		List<String> list;
 		
 		if (map.isEmpty()) {
@@ -241,11 +241,11 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 		
 		return list;
 	}
-	
 
 
 
-	List<String> createTimeSortedList(Map<String, Long> map) {
+
+	static List<String> createTimeSortedList(Map<String, Long> map) {
 		List<String> list = new ArrayList<String>();
 		
 		Collection<Long> valuesC = map.values();
@@ -271,7 +271,7 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 
 
 
-	private boolean isSymlink(File file) throws IOException {
+	static private boolean isSymlink(File file) throws IOException {
 		if (file == null)
 			throw new NullPointerException("File must not be null");
 		File canon;

--- a/src/main/java/alex/jenkins/plugins/FileSystemListParameterDefinition.java
+++ b/src/main/java/alex/jenkins/plugins/FileSystemListParameterDefinition.java
@@ -117,8 +117,6 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 	private String regexExcludePattern;
 
 	private String value;
-
-	SortedMap<String, Long> map;
 	
 	
 	
@@ -192,35 +190,35 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 
 
 	public List<String> getFsObjectsList() throws IOException {
-		
-		map = new TreeMap<String, Long>();
+
+		TreeMap<String, Long> map = new TreeMap<>();
 		File rootDir = new File(path);
 		File[] listFiles = rootDir.listFiles();
 		
 		if(listFiles!=null){
 			switch (getSelectedEnumType()) {
 			case SYMLINK:
-				createSymlinkMap(listFiles);
+				createSymlinkMap(listFiles, map);
 				break;
 			case DIRECTORY:
-				createDirectoryMap(listFiles);
+				createDirectoryMap(listFiles, map);
 				break;
 			case FILE:
-				createFileMap(listFiles);
+				createFileMap(listFiles, map);
 				break;
 			default:
-				createAllObjectsMap(listFiles);
+				createAllObjectsMap(listFiles, map);
 				break;
 			}
 		}
 		
 
-		return sortList();
+		return sortList(map);
 	}
 
 
 
-	List<String> sortList() {
+	List<String> sortList(Map<String, Long> map) {
 		List<String> list;
 		
 		if (map.isEmpty()) {
@@ -231,7 +229,7 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 		}else {
 			// Sorting:
 			if (isSortByLastModified()) {
-				list = createTimeSortedList();
+				list = createTimeSortedList(map);
 			}else {
 				list = new ArrayList<String>();
 				list.addAll(map.keySet());
@@ -247,7 +245,7 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 
 
 
-	List<String> createTimeSortedList() {
+	List<String> createTimeSortedList(Map<String, Long> map) {
 		List<String> list = new ArrayList<String>();
 		
 		Collection<Long> valuesC = map.values();
@@ -304,33 +302,33 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 	}
 
 		
-	private void createSymlinkMap(File[] listFiles) throws IOException {
+	private void createSymlinkMap(File[] listFiles, Map<String, Long> target) throws IOException {
 		
 		for (File file : listFiles) {
 			if (!file.isHidden() && isSymlink(file) && isPatternMatching(file.getName())) {
-				map.put(file.getName(),file.lastModified());
+				target.put(file.getName(),file.lastModified());
 				LOGGER.finest("add " + file);
 			}
 		}
 	}
 
 
-	private void createDirectoryMap(File[] listFiles) throws IOException {
+	private void createDirectoryMap(File[] listFiles, Map<String, Long> target) throws IOException {
 		
 		for (File file : listFiles) {
 			if (!file.isHidden() && file.isDirectory() && !isSymlink(file) && isPatternMatching(file.getName())) {
-				map.put(file.getName(),file.lastModified());
+				target.put(file.getName(),file.lastModified());
 				LOGGER.finest("add " + file);
 			}
 		}
 	}
 
 
-	private void createFileMap(File[] listFiles) throws IOException {
+	private void createFileMap(File[] listFiles, Map<String, Long> target) throws IOException {
 		
 		for (File file : listFiles) {
 			if (!file.isHidden() && file.isFile() && !isSymlink(file) && isPatternMatching(file.getName())) {
-				map.put(file.getName(),file.lastModified());
+				target.put(file.getName(),file.lastModified());
 				LOGGER.finest("add " + file);
 			}
 		}
@@ -340,11 +338,11 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 
 
 
-	private void createAllObjectsMap(File[] listFiles) {
+	private void createAllObjectsMap(File[] listFiles, Map<String, Long> target) {
 		
 		for (File file : listFiles) {
 			if (!file.isHidden() && isPatternMatching(file.getName())) {
-				map.put(file.getName(),file.lastModified());
+				target.put(file.getName(),file.lastModified());
 				LOGGER.finest("add " + file);
 			}
 		}

--- a/src/main/java/alex/jenkins/plugins/FileSystemListParameterDefinition.java
+++ b/src/main/java/alex/jenkins/plugins/FileSystemListParameterDefinition.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.logging.Logger;
@@ -74,8 +75,9 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 			if(!dir.exists()) {
 				return FormValidation.error(Messages.FileSystemListParameterDefinition_PathDoesntExist(), path);
 			}
-						
-			if(dir.list().length == 0) {
+
+			String[] items = dir.list();
+			if(items == null || items.length == 0) {
 				return FormValidation.warning(Messages.FileSystemListParameterDefinition_NoObjectsFound(), path);
 			}
 			return FormValidation.ok();
@@ -258,9 +260,9 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 			if (map.containsValue(value)) {
 
 				// key with lowest value will be added first
-				for (String key : map.keySet()) {
-					if (value == map.get(key)) {
-						list.add(key);
+				for (Map.Entry<String, Long> entry : map.entrySet()) {
+					if (value.equals(entry.getValue())) {
+						list.add(entry.getKey());
 					}
 				}
 			}

--- a/src/main/java/alex/jenkins/plugins/FileSystemListParameterDefinition.java
+++ b/src/main/java/alex/jenkins/plugins/FileSystemListParameterDefinition.java
@@ -15,7 +15,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Formatter;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -117,8 +116,6 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 
 	private String value;
 
-	private Formatter formatter;
-
 	SortedMap<String, Long> map;
 	
 	
@@ -138,7 +135,6 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 		this.sortReverseOrder = sortReverseOrder;
 		this.regexIncludePattern = regexIncludePattern;
 		this.regexExcludePattern = regexExcludePattern;
-		this.formatter = new Formatter();
 
 	}
 
@@ -175,7 +171,7 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 		try {
 			defaultValue = getEffectiveDefaultValue();
 		} catch (IOException e) {
-			LOGGER.warning(formatter.format(Messages.FileSystemListParameterDefinition_SymlinkDetectionError(), defaultValue).toString());
+			LOGGER.warning(String.format(Messages.FileSystemListParameterDefinition_SymlinkDetectionError(), defaultValue).toString());
 		}
 		if(!StringUtils.isBlank(defaultValue)) {
 			return new FileSystemListParameterValue(getName(), defaultValue);
@@ -227,7 +223,7 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 		
 		if (map.isEmpty()) {
 			list = new ArrayList<String>();
-			String msg = formatter.format(Messages.FileSystemListParameterDefinition_NoObjectsFoundAtPath(), getSelectedEnumType(), getRegexIncludePattern(), getRegexExcludePattern(), getPath()).toString() ;
+			String msg = String.format(Messages.FileSystemListParameterDefinition_NoObjectsFoundAtPath(), getSelectedEnumType(), getRegexIncludePattern(), getRegexExcludePattern(), getPath()).toString() ;
 			LOGGER.warning(msg);
 			list.add(msg);
 		}else {

--- a/src/main/resources/alex/jenkins/plugins/FileSystemListParameterDefinition/config.jelly
+++ b/src/main/resources/alex/jenkins/plugins/FileSystemListParameterDefinition/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
 

--- a/src/main/resources/alex/jenkins/plugins/FileSystemListParameterDefinition/index.jelly
+++ b/src/main/resources/alex/jenkins/plugins/FileSystemListParameterDefinition/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
   xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
   xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">

--- a/src/main/resources/alex/jenkins/plugins/FileSystemListParameterValue/value.jelly
+++ b/src/main/resources/alex/jenkins/plugins/FileSystemListParameterValue/value.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,6 +1,7 @@
 <!--
   This view is used to render the installed plugins page.
 -->
+<?jelly escape-by-default='true'?>
 <div>
   Plugin lists file system objects to choose as build parameter
 </div>

--- a/src/test/java/alex/jenkins/plugins/ChangeSequenceTest.java
+++ b/src/test/java/alex/jenkins/plugins/ChangeSequenceTest.java
@@ -8,28 +8,22 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class ChangeSequenceTest {
-
-	
-
-	public void setup(){
-	}
 	
 	@Test
 	public void testSorting() {
 		boolean sortByLastModified = true;
 		boolean sortReverseOrder = false;
-		FileSystemListParameterDefinition pd = new FileSystemListParameterDefinition("name", "description", "path", "FILE", "", "", sortByLastModified, sortReverseOrder);
-		
-		pd.map = new TreeMap<String, Long>();
+
+		TreeMap<String, Long> map = new TreeMap<>();
 		String test1 = "test1";
 		String test2 = "test2";
 		File f1 = new File(test1);
 		File f2 = new File(test2);
 
-		pd.map.put(f1.getName(), (long) 2);
-		pd.map.put(f2.getName(), (long) 1);
+		map.put(f1.getName(), (long) 2);
+		map.put(f2.getName(), (long) 1);
 		
-		List<String> sortedList = pd.createTimeSortedList();
+		List<String> sortedList = FileSystemListParameterDefinition.createTimeSortedList(map);
 		
 		Assert.assertEquals(test2,sortedList.get(0));
 		Assert.assertEquals(test1,sortedList.get(1));
@@ -42,17 +36,17 @@ public class ChangeSequenceTest {
 		boolean sortByLastModified = true;
 		boolean sortReverseOrder = true;
 		FileSystemListParameterDefinition pd = new FileSystemListParameterDefinition("name", "description", "path", "FILE", "", "", sortByLastModified, sortReverseOrder);
-		
-		pd.map = new TreeMap<String, Long>();
+
+		TreeMap<String, Long> map = new TreeMap<>();
 		String test1 = "test1";
 		String test2 = "test2";
 		File f1 = new File(test1);
 		File f2 = new File(test2);
 		
-		pd.map.put(f1.getName(), (long) 2);
-		pd.map.put(f2.getName(), (long) 1);
+		map.put(f1.getName(), (long) 2);
+		map.put(f2.getName(), (long) 1);
 		
-		List<String> sortedList = pd.sortList();
+		List<String> sortedList = pd.sortList(map);
 		
 		Assert.assertEquals(test1,sortedList.get(0));
 		Assert.assertEquals(test2,sortedList.get(1));
@@ -65,8 +59,8 @@ public class ChangeSequenceTest {
 		boolean sortByLastModified = false;
 		boolean sortReverseOrder = false;
 		FileSystemListParameterDefinition pd = new FileSystemListParameterDefinition("name", "description", "path", "FILE", "", "", sortByLastModified, sortReverseOrder);
-		
-		pd.map = new TreeMap<String, Long>();
+
+		TreeMap<String, Long> map = new TreeMap<>();
 		String test1 = "test1";
 		String test2 = "test2";
 		String test3 = "test3";
@@ -74,11 +68,11 @@ public class ChangeSequenceTest {
 		File f2 = new File(test2);
 		File f3 = new File(test3);
 		
-		pd.map.put(f1.getName(), (long) 1);
-		pd.map.put(f3.getName(), (long) 3);
-		pd.map.put(f2.getName(), (long) 2);
+		map.put(f1.getName(), (long) 1);
+		map.put(f3.getName(), (long) 3);
+		map.put(f2.getName(), (long) 2);
 		
-		List<String> sortedList = pd.sortList();
+		List<String> sortedList = pd.sortList(map);
 		
 		Assert.assertEquals(test1,sortedList.get(0));
 		Assert.assertEquals(test2,sortedList.get(1));

--- a/src/test/java/alex/jenkins/plugins/FileSystemListParameterDefinitionTest.java
+++ b/src/test/java/alex/jenkins/plugins/FileSystemListParameterDefinitionTest.java
@@ -1,0 +1,28 @@
+package alex.jenkins.plugins;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersDefinitionProperty;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.For;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+@For(FileSystemListParameterDefinition.class)
+public class FileSystemListParameterDefinitionTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("JENKINS-49649")
+    public void smokeRoundtrip() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        FileSystemListParameterDefinition d = new FileSystemListParameterDefinition("name", "description", "path", "FILE", "", "", true, false);
+        ParametersDefinitionProperty params = new ParametersDefinitionProperty(d);
+        p.addProperty(params);
+
+        j.configRoundtrip(p);
+    }
+
+}


### PR DESCRIPTION

- [x] - Update the plugin's pom.xml
- [x] - Make Jenkins 1.625.3 as a new baseline. This version is more than 3 years old, more than 95% of users run newer versions according to http://stats.jenkins.io/pluginversions/filesystem-list-parameter-plugin.html
- [x] - Add Jenkinsfile for ci.jenkins.io
- [x] - Pull in #1 from @hdoedens, which apparently fixes the issue
- [x] - Also stop serializing File caches which are not used. Non-whitelisted collection types cause issues in other plugins, it is better to reduce the footprint of the issue

https://issues.jenkins-ci.org/browse/JENKINS-49649

@reviewbybees @jglick 