### PR TITLE
fix: fix conflict with jquery lib (JENKINS-73112 JENKINS-73159)

### DIFF
--- a/src/main/resources/alex/jenkins/plugins/FileSystemListParameterDefinition/config.jelly
+++ b/src/main/resources/alex/jenkins/plugins/FileSystemListParameterDefinition/config.jelly
@@ -10,12 +10,12 @@
 		<f:textarea name="parameter.description" value="${instance.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
 	</f:entry>
 	
-	<f:entry title="NodeName" field="nodeName">
-      <select name="nodeName" >
+	<f:entry title="NodeName" field="selected-nodeName">
+      <select name="selected-nodeName" >
         <j:invokeStatic className="alex.jenkins.plugins.FileSystemListParameterDefinition" method="getNodeNames" var="nodeList" />
         <j:forEach var="node" items="${nodeList}" varStatus="loop">
             <j:choose>
-                <j:when test="${instance.nodeName.equals(node)}">
+                <j:when test="${instance.selected-nodeName.equals(node)}">
                     <option value="${node}" selected="selected">${node}</option>
                 </j:when>
                 <j:otherwise>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This is a fix for the conflict with jquery lib that many other plugins use
This fix should resolve [JENKINS-73112](https://issues.jenkins.io/browse/JENKINS-73112) and [JENKINS-73159](https://issues.jenkins.io/browse/JENKINS-73159)
Has been tested on my self-hosted jenkins that it successfully resolved the issue

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
