### PR TITLE
Require Jenkins 2.479.1 or newer

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 21
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(
     configurations: [
-        [platform: 'linux', jdk: 11],
-        [platform: 'windows', jdk: 11],
+        [platform: 'linux', jdk: 21],
+        [platform: 'windows', jdk: 17],
     ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.53</version>
+    <version>5.3</version>
+    <relativePath />
   </parent>
 
   <groupId>aendter.jenkins.plugins</groupId>
@@ -12,12 +15,11 @@
   <packaging>hpi</packaging>
 
   <name>Jenkins Filesystem List Parameter Plug-in</name>
-  <description>
-  This plugin reads folder, file or symbolic link names from filesystem path as parameter value.
-    </description>
 
   <properties>
-    <jenkins.version>2.430</jenkins.version>
+    <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
   </properties>
 
   <licenses>
@@ -28,13 +30,13 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:git@github.com:jenkinsci/filesystem-list-parameter-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/filesystem-list-parameter-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/filesystem-list-parameter-plugin</url>
-    <tag>filesystem-list-parameter-plugin-0.0.11</tag>
+    <connection>scm:git:https://github.com/${gitHubRepo}</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
+    <tag>${scmTag}</tag>
   </scm>
 
-  <url>https://wiki.jenkins.io/display/JENKINS/Filesystem+List+Parameter+Plug-in</url>
+  <url>https://github.com/${gitHubRepo}</url>
 
   <developers>
     <developer>
@@ -61,12 +63,21 @@
     </pluginRepository>
   </pluginRepositories>
 
-
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>3696.vb_b_4e2d1a_0542</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
       <artifactId>rebuild</artifactId>
-      <version>330.v645b_7df10e2a_</version>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/src/main/java/alex/jenkins/plugins/FileSystemListParameterDefinition.java
+++ b/src/main/java/alex/jenkins/plugins/FileSystemListParameterDefinition.java
@@ -21,7 +21,7 @@ import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import hudson.Extension;
 import hudson.FilePath;
@@ -182,7 +182,7 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 	}
 
 	@Override
-	public ParameterValue createValue(StaplerRequest request) {
+	public ParameterValue createValue(StaplerRequest2 request) {
 		String value[] = request.getParameterValues(getName());
 		if (value == null) {
 			return getDefaultParameterValue();
@@ -191,7 +191,7 @@ public class FileSystemListParameterDefinition extends ParameterDefinition {
 	}
 
 	@Override
-	public ParameterValue createValue(StaplerRequest request, JSONObject jO) {
+	public ParameterValue createValue(StaplerRequest2 request, JSONObject jO) {
 		Object value = jO.get("value");
 		String strValue = "";
 		if (value instanceof String) {


### PR DESCRIPTION
## Require Jenkins 2.479.1 or newer

While attempting to fix [JENKINS-74886](https://issues.jenkins.io/browse/JENKINS-74886), I upgraded the minimum Jenkins version to Jenkins 2.479.1 and replaced the StaplerRequest references with StaplerRequest2.  Unfortunately, that did not fix the issue.

This is provided as a draft pull request in case it helps someone else with the issue.  It can be closed at any time.

### Testing done

Ran the plugin build inside Jenkins 2.486 and confirmed that it still ignores the parameter when the job is run from a curl POST request using buildWithParameters

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
